### PR TITLE
Debug item rarity upgrade system

### DIFF
--- a/ITEM RARITY/BUGFIX_SUMMARY.md
+++ b/ITEM RARITY/BUGFIX_SUMMARY.md
@@ -1,0 +1,57 @@
+# Item Rarity Format Issue - Bug Fix Summary
+
+## Problem Description
+The new upgrades system was failing due to inconsistent rarity name formats throughout the codebase. Different functions were expecting different formats of rarity names, causing lookup failures.
+
+## Root Cause Analysis
+
+### Format Inconsistencies Found:
+1. **RARITY object in mainLib.js**: Uses `sid` property with format like `"Common"`, `"Uncommon"`, etc.
+2. **Item lore storage**: Uses `dName` property with color codes like `"§7Common"`, `"§aUncommon"`, etc.
+3. **UPGRADE_COSTS keys**: Uses uppercase format like `"COMMON"`, `"UNCOMMON"`, etc.
+4. **getItemRarity() function**: Was extracting and converting to uppercase inconsistently
+
+### Specific Issues:
+- `randomStats()`, `randomSkill()`, and `randomPassiveAbility()` functions were looking for `r.sid === rarity` but receiving inconsistent formats
+- `getItemRarity()` was using `.slice(2).toUpperCase()` which could fail with different input formats
+- Upgrade functions were using the output of `getItemRarity()` to lookup `UPGRADE_COSTS` but formats didn't match
+
+## Solution Implemented
+
+### 1. Added Helper Functions:
+```javascript
+// Normalizes any rarity format to consistent sid format ("Common", "Uncommon", etc.)
+function normalizeRarityName(rarity)
+
+// Converts any rarity format to uppercase for UPGRADE_COSTS lookup ("COMMON", "UNCOMMON", etc.)
+function rarityToUpgradeKey(rarity)
+```
+
+### 2. Fixed Core Functions:
+- **`getItemRarity()`**: Now properly handles all input formats and returns consistent uppercase keys
+- **`randomStats()`**: Uses `normalizeRarityName()` for consistent RARITY object lookup
+- **`randomSkill()`**: Uses `normalizeRarityName()` for consistent RARITY object lookup  
+- **`randomPassiveAbility()`**: Uses `normalizeRarityName()` for consistent RARITY object lookup
+
+### 3. Enhanced Error Handling:
+- Added validation to ensure unknown rarities fallback to safe defaults
+- Added null checks to prevent crashes when rarity objects aren't found
+
+## Formats Now Handled:
+- `"§7Common"` (with color codes)
+- `"Common"` (normal case)
+- `"COMMON"` (uppercase)
+- `"common"` (lowercase)
+- Any combination with extra whitespace
+
+## Files Modified:
+- `/workspace/ITEM RARITY/main.js`
+
+## Testing Recommendations:
+1. Test rarity upgrades with items of all rarity levels
+2. Test stats/skill/passive rerolls and upgrades
+3. Verify that newly generated items work with the upgrade system
+4. Check that items with various lore formats are handled correctly
+
+## Result:
+The upgrades system should now work consistently regardless of how rarity names are formatted in the item lore, eliminating the format-related failures in the new upgrades system.


### PR DESCRIPTION
Fix item rarity format inconsistencies to resolve upgrade system failures.

The upgrade system, and other related functions, were failing due to a mismatch in rarity name formats. Item lore used color codes (e.g., '§7Common'), the `RARITY` object used proper case ('Common'), and `UPGRADE_COSTS` expected uppercase ('COMMON'), causing lookups to fail. This PR introduces helper functions and updates existing logic to normalize rarity names across the codebase.