### PR TITLE
Fix item rarity errors

### DIFF
--- a/ITEM RARITY/divinePassives.js
+++ b/ITEM RARITY/divinePassives.js
@@ -10,96 +10,96 @@ import {
 export const DIVINE_PASSIVES = [
     // FROST TOUCH — melee weapons
     {
+        id: 1,
         name: "§bFrost Touch",
         type: meleeWeapons,
-        rarity: "Divine",
         min: 3,
         max: 5,
-        description: "Slow enemy for §x{x}§7 seconds on hit. 5% chance to set powdered snow below the enemy.",
+        description: "Slow enemy for {value} seconds on hit. 5% chance to set powdered snow below the enemy.",
         cooldown: 20,
         scoreboard: "frosttouch"
     },
 
     // LIGHTNING STRIKE — all weapons
     {
+        id: 2,
         name: "§bLightning Strike",
         type: allWeapons,
-        rarity: "Divine",
         min: 25,
         max: 40,
-        description: "§x{x}§7% chance to strike lightning on enemy hit.",
+        description: "{value}% chance to strike lightning on enemy hit.",
         cooldown: 20,
         scoreboard: "lightningstrike"
     },
 
     // VAMPIRIC — melee weapons (full moon)
     {
+        id: 3,
         name: "§bVampiric",
         type: meleeWeapons,
-        rarity: "Divine",
         min: 50,
         max: 75,
-        description: "During full moon: Heal §x{x}§7% of damage dealt.",
+        description: "During full moon: Heal {value}% of damage dealt.",
         cooldown: 20,
         scoreboard: "vampiric"
     },
 
     // POISON BLADE — melee weapons
     {
+        id: 4,
         name: "§bPoison Blade",
         type: meleeWeapons,
-        rarity: "Divine",
         min: 8,
         max: 12,
-        description: "Apply Poison for §x{x}§7 seconds on hit.",
+        description: "Apply Poison for {value} seconds on hit.",
         cooldown: 10,
         scoreboard: "poisonblade"
     },
 
     // EXPLOSIVE ARROWS — ranged weapons
     {
+        id: 5,
         name: "§bExplosive Arrows",
         type: rangedWeapons,
-        rarity: "Divine",
         min: 10,
         max: 15,
-        description: "Arrows explode with power §x{x}§7 on impact.",
+        description: "Arrows explode with power {value} on impact.",
         cooldown: 300,
         scoreboard: "explosivearrows"
     },
 
     // ENDER ARROW — ranged weapons
     {
+        id: 6,
         name: "§bEnder Arrow",
         type: rangedWeapons,
-        rarity: "Divine",
         min: 100,
         max: 100,
-        description: "Can shoot Endermen. §x{x}§7% increased hit chance against Endermen.",
+        description: "Can shoot Endermen. {value}% increased hit chance against Endermen.",
         cooldown: 20,
         scoreboard: "enderarrow"
     },
 
     // DRAGON ARMOR — chestplate
     {
+        id: 7,
         name: "§bDragon Armor",
         type: "chestplate",
-        rarity: "Divine",
         min: 60,
         max: 90,
-        description: "When receiving fire damage: Gain Fire Resistance for §x{x}§7 seconds.",
+        description: "When receiving fire damage: Gain Fire Resistance for {value} seconds.",
         cooldown: 500,
         scoreboard: "dragonarmor"
     },
 
     // AEGIS — helmet
     {
+        id: 8,
         name: "§bAegis",
         type: "helmet",
-        rarity: "Divine",
         min: 2,
         max: 3,
-        description: "Block §x{x}§7 negative effects.",
+        description: "Block {value} negative effects.",
         cooldown: 50,
         scoreboard: "aegis"
     }

--- a/ITEM RARITY/divinePassives.js
+++ b/ITEM RARITY/divinePassives.js
@@ -1,0 +1,106 @@
+import {
+    allWeapons,
+    allArmor,
+    meleeWeapons,
+    rangedWeapons,
+    tools,
+    allItems
+} from './mainLib.js';
+
+export const DIVINE_PASSIVES = [
+    // FROST TOUCH — melee weapons
+    {
+        name: "§bFrost Touch",
+        type: meleeWeapons,
+        rarity: "Divine",
+        min: 3,
+        max: 5,
+        description: "Slow enemy for §x{x}§7 seconds on hit. 5% chance to set powdered snow below the enemy.",
+        cooldown: 20,
+        scoreboard: "frosttouch"
+    },
+
+    // LIGHTNING STRIKE — all weapons
+    {
+        name: "§bLightning Strike",
+        type: allWeapons,
+        rarity: "Divine",
+        min: 25,
+        max: 40,
+        description: "§x{x}§7% chance to strike lightning on enemy hit.",
+        cooldown: 20,
+        scoreboard: "lightningstrike"
+    },
+
+    // VAMPIRIC — melee weapons (full moon)
+    {
+        name: "§bVampiric",
+        type: meleeWeapons,
+        rarity: "Divine",
+        min: 50,
+        max: 75,
+        description: "During full moon: Heal §x{x}§7% of damage dealt.",
+        cooldown: 20,
+        scoreboard: "vampiric"
+    },
+
+    // POISON BLADE — melee weapons
+    {
+        name: "§bPoison Blade",
+        type: meleeWeapons,
+        rarity: "Divine",
+        min: 8,
+        max: 12,
+        description: "Apply Poison for §x{x}§7 seconds on hit.",
+        cooldown: 10,
+        scoreboard: "poisonblade"
+    },
+
+    // EXPLOSIVE ARROWS — ranged weapons
+    {
+        name: "§bExplosive Arrows",
+        type: rangedWeapons,
+        rarity: "Divine",
+        min: 10,
+        max: 15,
+        description: "Arrows explode with power §x{x}§7 on impact.",
+        cooldown: 300,
+        scoreboard: "explosivearrows"
+    },
+
+    // ENDER ARROW — ranged weapons
+    {
+        name: "§bEnder Arrow",
+        type: rangedWeapons,
+        rarity: "Divine",
+        min: 100,
+        max: 100,
+        description: "Can shoot Endermen. §x{x}§7% increased hit chance against Endermen.",
+        cooldown: 20,
+        scoreboard: "enderarrow"
+    },
+
+    // DRAGON ARMOR — chestplate
+    {
+        name: "§bDragon Armor",
+        type: "chestplate",
+        rarity: "Divine",
+        min: 60,
+        max: 90,
+        description: "When receiving fire damage: Gain Fire Resistance for §x{x}§7 seconds.",
+        cooldown: 500,
+        scoreboard: "dragonarmor"
+    },
+
+    // AEGIS — helmet
+    {
+        name: "§bAegis",
+        type: "helmet",
+        rarity: "Divine",
+        min: 2,
+        max: 3,
+        description: "Block §x{x}§7 negative effects.",
+        cooldown: 50,
+        scoreboard: "aegis"
+    }
+];

--- a/ITEM RARITY/divineSkills.js
+++ b/ITEM RARITY/divineSkills.js
@@ -1,0 +1,106 @@
+import {
+    allWeapons,
+    allArmor,
+    meleeWeapons,
+    rangedWeapons,
+    tools,
+    allItems
+} from './mainLib.js';
+
+export const DIVINE_SKILLS = [
+    // SMASH LEAP - Mace
+    {
+        name: "§bSmash Leap",
+        type: "mace",
+        rarity: "Divine",
+        min: 7,
+        max: 10,
+        description: "Smashes the ground and stuns enemies in §x{x}§7 blocks radius, then leaps 8 blocks if has wind charge",
+        cooldown: 120,
+        scoreboard: "smashleap"
+    },
+
+    // SPIN STRIKE - Sword
+    {
+        name: "§bSpin Strike",
+        type: "sword",
+        rarity: "Divine",
+        min: 20,
+        max: 30,
+        description: "Performs a 360° spin attack, dealing §x{x}§7 damage to all enemies within 3 blocks",
+        cooldown: 60,
+        scoreboard: "spinstrike"
+    },
+
+    // EXPLOSIVE MINING - Pickaxe
+    {
+        name: "§bExplosive Mining",
+        type: "pickaxe",
+        rarity: "Divine",
+        min: 10,
+        max: 15,
+        description: "Creates an explosion with size of §x{x}§7 to break blocks and damage enemies",
+        cooldown: 1000,
+        scoreboard: "explosivemining"
+    },
+
+    // RAY MINER - Pickaxe
+    {
+        name: "§bRay Miner",
+        type: "pickaxe",
+        rarity: "Divine",
+        min: 25,
+        max: 35,
+        description: "Breaks §x{x}§7 blocks in a straight line through solid materials",
+        cooldown: 180,
+        scoreboard: "rayminer"
+    },
+
+    // EXCAVATOR - Shovel
+    {
+        name: "§bExcavator",
+        type: "shovel",
+        rarity: "Divine",
+        min: 12,
+        max: 18,
+        description: "Breaks sand-type blocks in a 3x3x§x{x}§7 area, consuming durability",
+        cooldown: 70,
+        scoreboard: "excavator"
+    },
+
+    // FLAME ARC - Sword
+    {
+        name: "§bFlame Arc",
+        type: "sword",
+        rarity: "Divine",
+        min: 50,
+        max: 75,
+        description: "Unleashes an arc of fire that ignites enemies and blocks, dealing §x{x}§7 fire damage",
+        cooldown: 200,
+        scoreboard: "flamearc"
+    },
+
+    // SHADOW DASH - Sword
+    {
+        name: "§bShadow Dash",
+        type: "sword",
+        rarity: "Divine",
+        min: 15,
+        max: 20,
+        description: "Dash forward §x{x}§7 blocks through enemies, reduced distance when airborne",
+        cooldown: 50,
+        scoreboard: "shadowdash"
+    },
+
+    // VOID PIERCE - Sword
+    {
+        name: "§bVoid Pierce",
+        type: "sword",
+        rarity: "Divine",
+        min: 25,
+        max: 40,
+        description: "Shoots a void projectile that pierces through enemies, dealing §x{x}§7 damage",
+        cooldown: 80,
+        scoreboard: "voidpierce"
+    },
+];

--- a/ITEM RARITY/divineSkills.js
+++ b/ITEM RARITY/divineSkills.js
@@ -10,96 +10,96 @@ import {
 export const DIVINE_SKILLS = [
     // SMASH LEAP - Mace
     {
+        id: 1,
         name: "§bSmash Leap",
         type: "mace",
-        rarity: "Divine",
         min: 7,
         max: 10,
-        description: "Smashes the ground and stuns enemies in §x{x}§7 blocks radius, then leaps 8 blocks if has wind charge",
+        description: "Smashes the ground and stuns enemies in {value} blocks radius, then leaps 8 blocks if has wind charge",
         cooldown: 120,
         scoreboard: "smashleap"
     },
 
     // SPIN STRIKE - Sword
     {
+        id: 2,
         name: "§bSpin Strike",
         type: "sword",
-        rarity: "Divine",
         min: 20,
         max: 30,
-        description: "Performs a 360° spin attack, dealing §x{x}§7 damage to all enemies within 3 blocks",
+        description: "Performs a 360° spin attack, dealing {value} damage to all enemies within 3 blocks",
         cooldown: 60,
         scoreboard: "spinstrike"
     },
 
     // EXPLOSIVE MINING - Pickaxe
     {
+        id: 3,
         name: "§bExplosive Mining",
         type: "pickaxe",
-        rarity: "Divine",
         min: 10,
         max: 15,
-        description: "Creates an explosion with size of §x{x}§7 to break blocks and damage enemies",
+        description: "Creates an explosion with size of {value} to break blocks and damage enemies",
         cooldown: 1000,
         scoreboard: "explosivemining"
     },
 
     // RAY MINER - Pickaxe
     {
+        id: 4,
         name: "§bRay Miner",
         type: "pickaxe",
-        rarity: "Divine",
         min: 25,
         max: 35,
-        description: "Breaks §x{x}§7 blocks in a straight line through solid materials",
+        description: "Breaks {value} blocks in a straight line through solid materials",
         cooldown: 180,
         scoreboard: "rayminer"
     },
 
     // EXCAVATOR - Shovel
     {
+        id: 5,
         name: "§bExcavator",
         type: "shovel",
-        rarity: "Divine",
         min: 12,
         max: 18,
-        description: "Breaks sand-type blocks in a 3x3x§x{x}§7 area, consuming durability",
+        description: "Breaks sand-type blocks in a 3x3x{value} area, consuming durability",
         cooldown: 70,
         scoreboard: "excavator"
     },
 
     // FLAME ARC - Sword
     {
+        id: 6,
         name: "§bFlame Arc",
         type: "sword",
-        rarity: "Divine",
         min: 50,
         max: 75,
-        description: "Unleashes an arc of fire that ignites enemies and blocks, dealing §x{x}§7 fire damage",
+        description: "Unleashes an arc of fire that ignites enemies and blocks, dealing {value} fire damage",
         cooldown: 200,
         scoreboard: "flamearc"
     },
 
     // SHADOW DASH - Sword
     {
+        id: 7,
         name: "§bShadow Dash",
         type: "sword",
-        rarity: "Divine",
         min: 15,
         max: 20,
-        description: "Dash forward §x{x}§7 blocks through enemies, reduced distance when airborne",
+        description: "Dash forward {value} blocks through enemies, reduced distance when airborne",
         cooldown: 50,
         scoreboard: "shadowdash"
     },
 
     // VOID PIERCE - Sword
     {
+        id: 8,
         name: "§bVoid Pierce",
         type: "sword",
-        rarity: "Divine",
         min: 25,
         max: 40,
-        description: "Shoots a void projectile that pierces through enemies, dealing §x{x}§7 damage",
+        description: "Shoots a void projectile that pierces through enemies, dealing {value} damage",
         cooldown: 80,
         scoreboard: "voidpierce"
     },

--- a/ITEM RARITY/main.js
+++ b/ITEM RARITY/main.js
@@ -1102,7 +1102,8 @@ function divineMenu(player) {
     let divineLevelBar = "";
     for (const line of loreArray) {
         if (line.includes(DIVINE_LEVEL_MARKER)) {
-            divineLevelBar = line.slice(DIVINE_LEVEL_MARKER.length).replace(" ", "\n");
+            const markerIndex = line.indexOf(DIVINE_LEVEL_MARKER);
+            divineLevelBar = line.substring(markerIndex + DIVINE_LEVEL_MARKER.length).replace(" ", "\n");
             break;
         }
     }
@@ -3289,13 +3290,14 @@ function updateItemPoints(itemStack, newPoints) {
     if (dataLineIndex === -1) {
         
         const newDataLine = `${DIVINE_DATA_MARKER}${DIVINE_DATA_STRING_BASE}`;
+        const newDataEndLine = `${DIVINE_DATA_MARKER_END}`;
         // Add new points line - try to place it after the divine level line
         const divinePointsLineIndex = newLore.findIndex(line => line.includes(DIVINE_POINTS_MARKER));
         if (divinePointsLineIndex !== -1) {
-            newLore.splice(divinePointsLineIndex + 1, 0, newDataLine);
+            newLore.splice(divinePointsLineIndex + 1, 0, newDataLine, newDataEndLine);
         } else {
             // If no divine level line found, add at the end
-            newLore.push(newDataLine);
+            newLore.push(newDataLine, newDataEndLine);
         }
     }
     


### PR DESCRIPTION
Add `divineSkills.js` and `divinePassives.js`, fix a "d" character display bug in `openDivineMenu`, and ensure the `DIVINE_DATA_MARKER_END` is added with `DIVINE_DATA_MARKER`.

The "d" character bug in `openDivineMenu` was caused by incorrect string slicing that failed to account for the invisible `§d` color code within the `DIVINE_LEVEL_MARKER`, leading to the 'd' being visible. The missing `DIVINE_DATA_MARKER_END` prevented the `replaceArrayBetweenMarkers` function from working correctly when divine data was first added.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6b48fc6-80b5-4095-860b-dd7f3027a108">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6b48fc6-80b5-4095-860b-dd7f3027a108">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

